### PR TITLE
Add PHP password_hash definite identification

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -53,7 +53,7 @@ starts_with(const char *a, const char *b)
 static void
 dprint(char *name)
 {
-	printf("[" RED "+" RESET "] Definite identification %s\n", name);
+	printf("[" RED "+" RESET "] Definite identification: %s\n", name);
 }
 
 
@@ -83,6 +83,8 @@ definite(char string[], int length)
 		dprint("SHA1 Django");
 	else if (length==65 && string[32]==':')
 		dprint("MD5 Joomla (pass:salt)");
+	else if (starts_with(string, "$2y$"))
+		dprint("PHP password_hash");
 }
 
 /* this function determines charset*/

--- a/src/select.c
+++ b/src/select.c
@@ -157,5 +157,6 @@ list(void)
 	"ARP1           \n"
 	"phpBB          \n"
 	"SHA1 Django    \n"
+	"PHP password_hash\n"
 	"MD5 Joomla (pass:salt)\n");
 }


### PR DESCRIPTION
PHP's password_hash() function returns a hash that starts with $2y$,
followed by the cost.

To test:

~~~bash
houndsniff "\$2y\$10\$imIIRWpdT/e4.VF8/USJwO9LyLcDzAPVzrBilmiaPbGzcc8jve97i"
~~~